### PR TITLE
Support adding specific Node.js versions into the matrix

### DIFF
--- a/.github/actions/prepare-node-test-matrix-action/action.yaml
+++ b/.github/actions/prepare-node-test-matrix-action/action.yaml
@@ -7,19 +7,40 @@ runs:
   main: index.js
 
 inputs:
+
   upgrade-policy:
     description: "Node.js version upgrade policy. Allowed values: `lts` (default), `lts/strict`, `all`."
     default: lts
     required: false
+
   runs-on:
     description: "Comma separated list of runner labels (note: not YAML!), see https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idruns-on."
     default: "ubuntu-latest"
     required: false
 
+  include:
+    description: "A string with additional matrix combinations as YAML array of objects with the following keys: node-version, runs-on, experimental"
+    default: "[]"
+    required: false
+
+  exclude:
+    description: "A string with matrix combinations to be skipped as a YAML array of objects with the following keys: node-version, runs-on"
+    default: "[]"
+    required: false
+
 outputs:
+
   node-version:
     description: "A JSON with a list of Node.js versions matching the upgrade policy, where the minimum version is the one defined in the `package.json` `engines.node` field."
+
   lts-latest:
     description: "Which version of node is the latest active LTS."
+
   runs-on:
-    description: "A JSON with a list of OS versions for use in `jobs.<job_id>.runs-on`"
+    description: "A JSON with a list of OS versions for use in `jobs.<job_id>.runs-on`."
+
+  include:
+    description: "A JSON with additional matrix combinations."
+
+  exclude:
+    description: "A JSON with matrix combinations that should be skipped."

--- a/.github/actions/prepare-node-test-matrix-action/action.yaml
+++ b/.github/actions/prepare-node-test-matrix-action/action.yaml
@@ -17,7 +17,7 @@ inputs:
     required: false
 
 outputs:
-  matrix:
+  node-version:
     description: "A JSON with a list of Node.js versions matching the upgrade policy, where the minimum version is the one defined in the `package.json` `engines.node` field."
   lts-latest:
     description: "Which version of node is the latest active LTS."

--- a/.github/actions/prepare-node-test-matrix-action/index.js
+++ b/.github/actions/prepare-node-test-matrix-action/index.js
@@ -10,6 +10,7 @@ const ActionsCore = require('@actions/core');
 const Path = require('path');
 const Schedule = require('./schedule.json'); // https://raw.githubusercontent.com/nodejs/Release/master/schedule.json
 const Semver = require('semver');
+const Yaml = require('yaml');
 
 
 // package.json from the system being tested
@@ -41,6 +42,9 @@ exports.main = function ({ now = new Date(), pkg = Package, debug = console.info
     if (upgradePolicy !== 'lts' && upgradePolicy !== 'lts/strict' && upgradePolicy !== 'all') {
         throw new Error(`No such upgrade policy: ${upgradePolicy}`);
     }
+
+    const include = Yaml.parse(ActionsCore.getInput('include') || '[]');
+    const exclude = Yaml.parse(ActionsCore.getInput('exclude') || '[]');
 
     const today = now.toISOString().substr(0, 10);
 
@@ -97,6 +101,9 @@ exports.main = function ({ now = new Date(), pkg = Package, debug = console.info
     const runsOnInput = ActionsCore.getInput('runs-on') || 'ubuntu-latest';
     const runsOn = runsOnInput.split(/[,\s]+/);
     internals.setOutput('runs-on', JSON.stringify(runsOn), { debug });
+
+    internals.setOutput('include', JSON.stringify(include), { debug });
+    internals.setOutput('exclude', JSON.stringify(exclude), { debug });
 };
 
 

--- a/.github/actions/prepare-node-test-matrix-action/index.js
+++ b/.github/actions/prepare-node-test-matrix-action/index.js
@@ -27,6 +27,18 @@ internals.setOutput = function (name, value, { debug }) {
 };
 
 
+internals.isExcluded = function (combo, exclude) {
+
+    return exclude.some((excludedCombo) => {
+
+        return Object.entries(excludedCombo).every(([k, v]) => {
+
+            return combo[k] === v;
+        });
+    });
+};
+
+
 exports.main = function ({ now = new Date(), pkg = Package, debug = console.info } = {}) {
 
     if (!pkg.engines || !pkg.engines.node) {
@@ -112,14 +124,17 @@ exports.main = function ({ now = new Date(), pkg = Package, debug = console.info
 
             if (!isLtsStarted) {
                 debug(`${version} - experimental: not yet LTS.`);
-                include.unshift(...runsOn.map((os) => {
+                include.unshift(...runsOn
+                    .map((os) => {
 
-                    return {
-                        'runs-on': os,
-                        'node-version': versionNumber,
-                        experimental: true
-                    };
-                }));
+                        return {
+                            'runs-on': os,
+                            'node-version': versionNumber,
+                            experimental: true
+                        };
+                    })
+                    .filter((combo) => !internals.isExcluded(combo, exclude))
+                );
                 continue;
             }
         }

--- a/.github/actions/prepare-node-test-matrix-action/index.js
+++ b/.github/actions/prepare-node-test-matrix-action/index.js
@@ -48,8 +48,8 @@ exports.main = function ({ now = new Date(), pkg = Package, debug = console.info
     const include = Yaml.parse(ActionsCore.getInput('include') || '[]');
     const exclude = Yaml.parse(ActionsCore.getInput('exclude') || '[]');
 
-    const runsOnInput = ActionsCore.getInput('runs-on') || 'ubuntu-latest';
-    const runsOn = runsOnInput.split(/[,\s]+/);
+    const runsOnInput = Yaml.parse(ActionsCore.getInput('runs-on') || 'ubuntu-latest');
+    const runsOn = Array.isArray(runsOnInput) ? runsOnInput : runsOnInput.split(/[,\s]+/);
 
     const versions = [];
     let ltsLatest = 4; // oldest LTS - avoid returning undefined here

--- a/.github/actions/prepare-node-test-matrix-action/index.js
+++ b/.github/actions/prepare-node-test-matrix-action/index.js
@@ -91,7 +91,7 @@ exports.main = function ({ now = new Date(), pkg = Package, debug = console.info
     }
 
     const sorted = versions.sort((a, b) => b - a);
-    internals.setOutput('matrix', JSON.stringify(sorted), { debug });
+    internals.setOutput('node-version', JSON.stringify(sorted), { debug });
     internals.setOutput('lts-latest', ltsLatest, { debug });
 
     const runsOnInput = ActionsCore.getInput('runs-on') || 'ubuntu-latest';

--- a/.github/actions/prepare-node-test-matrix-action/index.js
+++ b/.github/actions/prepare-node-test-matrix-action/index.js
@@ -45,11 +45,36 @@ exports.main = function ({ now = new Date(), pkg = Package, debug = console.info
 
     const today = now.toISOString().substr(0, 10);
 
-    const include = Yaml.parse(ActionsCore.getInput('include') || '[]');
-    const exclude = Yaml.parse(ActionsCore.getInput('exclude') || '[]');
-
     const runsOnInput = Yaml.parse(ActionsCore.getInput('runs-on') || 'ubuntu-latest');
     const runsOn = Array.isArray(runsOnInput) ? runsOnInput : runsOnInput.split(/[,\s]+/);
+
+    const includeInput = Yaml.parse(ActionsCore.getInput('include') || '[]');
+    const include = [];
+
+    includeInput.forEach((matrixCombo) => {
+
+        const experimental = matrixCombo.experimental === undefined ? false : matrixCombo.experimental;
+
+        if (matrixCombo['runs-on'] !== undefined) {
+            include.push({
+                'runs-on': matrixCombo['runs-on'],
+                'node-version': matrixCombo['node-version'],
+                experimental
+            });
+        }
+        else {
+            runsOn.forEach((os) => {
+
+                include.push({
+                    'runs-on': os,
+                    'node-version': matrixCombo['node-version'],
+                    experimental
+                });
+            });
+        }
+    });
+
+    const exclude = Yaml.parse(ActionsCore.getInput('exclude') || '[]');
 
     const versions = [];
     let ltsLatest = 4; // oldest LTS - avoid returning undefined here

--- a/.github/actions/prepare-node-test-matrix-action/test/index.js
+++ b/.github/actions/prepare-node-test-matrix-action/test/index.js
@@ -59,24 +59,24 @@ exports.main = function () {
 
     process.env = { ...originalEnv };
     Assert.deepStrictEqual(exports.getOutput(new Date('2020-07-01'), { engines: { node: '^14' } }), [
-        '::set-output name=node-version::[14]',
+        '::set-output name=node-version::[]',
         '::set-output name=lts-latest::12',
         '::set-output name=runs-on::["ubuntu-latest"]',
-        '::set-output name=include::[]',
+        '::set-output name=include::[{"runs-on":"ubuntu-latest","node-version":14,"experimental":true}]',
         '::set-output name=exclude::[]'
     ]);
     Assert.deepStrictEqual(exports.getOutput(new Date('2020-07-01'), { engines: { node: '*' } }), [
-        '::set-output name=node-version::[14,12,10,8,6,4]',
+        '::set-output name=node-version::[12,10,8,6,4]',
         '::set-output name=lts-latest::12',
         '::set-output name=runs-on::["ubuntu-latest"]',
-        '::set-output name=include::[]',
+        '::set-output name=include::[{"runs-on":"ubuntu-latest","node-version":14,"experimental":true}]',
         '::set-output name=exclude::[]'
     ]);
     Assert.deepStrictEqual(exports.getOutput(new Date('2020-07-01'), { engines: { node: '^14 || ^12 || ^10' } }), [
-        '::set-output name=node-version::[14,12,10]',
+        '::set-output name=node-version::[12,10]',
         '::set-output name=lts-latest::12',
         '::set-output name=runs-on::["ubuntu-latest"]',
-        '::set-output name=include::[]',
+        '::set-output name=include::[{"runs-on":"ubuntu-latest","node-version":14,"experimental":true}]',
         '::set-output name=exclude::[]'
     ]);
     Assert.deepStrictEqual(exports.getOutput(new Date('2010-07-01'), { engines: { node: '*' } }), [
@@ -92,38 +92,38 @@ exports.main = function () {
 
     process.env = { ...originalEnv, 'INPUT_UPGRADE-POLICY': 'lts' };
     Assert.deepStrictEqual(exports.getOutput(new Date('2020-07-01'), { engines: { node: '^10' } }), [
-        '::set-output name=node-version::[14,12,10]',
+        '::set-output name=node-version::[12,10]',
         '::set-output name=lts-latest::12',
         '::set-output name=runs-on::["ubuntu-latest"]',
-        '::set-output name=include::[]',
+        '::set-output name=include::[{"runs-on":"ubuntu-latest","node-version":14,"experimental":true}]',
         '::set-output name=exclude::[]'
     ]);
     Assert.deepStrictEqual(exports.getOutput(new Date('2020-11-01'), { engines: { node: '^10' } }), [
-        '::set-output name=node-version::[15,14,12,10]',
+        '::set-output name=node-version::[14,12,10]',
         '::set-output name=lts-latest::14',
         '::set-output name=runs-on::["ubuntu-latest"]',
-        '::set-output name=include::[]',
+        '::set-output name=include::[{"runs-on":"ubuntu-latest","node-version":15,"experimental":true}]',
         '::set-output name=exclude::[]'
     ]);
     Assert.deepStrictEqual(exports.getOutput(new Date('2021-05-01'), { engines: { node: '^10' } }), [
-        '::set-output name=node-version::[16,15,14,12,10]',
+        '::set-output name=node-version::[14,12,10]',
         '::set-output name=lts-latest::14',
         '::set-output name=runs-on::["ubuntu-latest"]',
-        '::set-output name=include::[]',
+        '::set-output name=include::[{"runs-on":"ubuntu-latest","node-version":16,"experimental":true},{"runs-on":"ubuntu-latest","node-version":15,"experimental":true}]',
         '::set-output name=exclude::[]'
     ]);
     Assert.deepStrictEqual(exports.getOutput(new Date('2021-07-01'), { engines: { node: '^10' } }), [
-        '::set-output name=node-version::[16,14,12,10]',
+        '::set-output name=node-version::[14,12,10]',
         '::set-output name=lts-latest::14',
         '::set-output name=runs-on::["ubuntu-latest"]',
-        '::set-output name=include::[]',
+        '::set-output name=include::[{"runs-on":"ubuntu-latest","node-version":16,"experimental":true}]',
         '::set-output name=exclude::[]'
     ]);
     Assert.deepStrictEqual(exports.getOutput(new Date('2021-11-01'), { engines: { node: '^10' } }), [
-        '::set-output name=node-version::[17,16,14,12,10]',
+        '::set-output name=node-version::[16,14,12,10]',
         '::set-output name=lts-latest::16',
         '::set-output name=runs-on::["ubuntu-latest"]',
-        '::set-output name=include::[]',
+        '::set-output name=include::[{"runs-on":"ubuntu-latest","node-version":17,"experimental":true}]',
         '::set-output name=exclude::[]'
     ]);
 
@@ -206,10 +206,10 @@ exports.main = function () {
     // runs-on - simple comma separated list
     process.env = { ...originalEnv, 'INPUT_RUNS-ON': 'ubuntu-latest, windows-latest, macos-latest' };
     Assert.deepStrictEqual(exports.getOutput(new Date('2020-07-01'), { engines: { node: '^14' } }), [
-        '::set-output name=node-version::[14]',
+        '::set-output name=node-version::[]',
         '::set-output name=lts-latest::12',
         '::set-output name=runs-on::["ubuntu-latest","windows-latest","macos-latest"]',
-        '::set-output name=include::[]',
+        '::set-output name=include::[{"runs-on":"ubuntu-latest","node-version":14,"experimental":true},{"runs-on":"windows-latest","node-version":14,"experimental":true},{"runs-on":"macos-latest","node-version":14,"experimental":true}]',
         '::set-output name=exclude::[]'
     ]);
 };

--- a/.github/actions/prepare-node-test-matrix-action/test/index.js
+++ b/.github/actions/prepare-node-test-matrix-action/test/index.js
@@ -232,6 +232,17 @@ exports.main = function () {
         '::set-output name=include::[{"runs-on":"ubuntu-latest","node-version":14,"experimental":true},{"runs-on":"windows-latest","node-version":14,"experimental":true},{"runs-on":"macos-latest","node-version":14,"experimental":true},{"runs-on":"ubuntu-latest","node-version":15,"experimental":false},{"runs-on":"ubuntu-latest","node-version":13,"experimental":false},{"runs-on":"windows-latest","node-version":13,"experimental":false},{"runs-on":"macos-latest","node-version":13,"experimental":false}]',
         '::set-output name=exclude::[]'
     ]);
+
+    // excludes non-LTS experimental when explicitly requested
+    process.env = { ...originalEnv, 'INPUT_RUNS-ON': '- ubuntu-latest\n- windows-latest\n- macos-latest\n', 'INPUT_EXCLUDE': '- node-version: 17\n  runs-on: ubuntu-latest' };
+    Assert.deepStrictEqual(exports.getOutput(new Date('2021-11-01'), { engines: { node: '^10' } }), [
+        '::set-output name=node-version::[16,14,12,10]',
+        '::set-output name=lts-latest::16',
+        '::set-output name=runs-on::["ubuntu-latest","windows-latest","macos-latest"]',
+        // node 17 on ubuntu latest explicitly excluded
+        '::set-output name=include::[{"runs-on":"windows-latest","node-version":17,"experimental":true},{"runs-on":"macos-latest","node-version":17,"experimental":true}]',
+        '::set-output name=exclude::[{"node-version":17,"runs-on":"ubuntu-latest"}]'
+    ]);
 };
 
 

--- a/.github/actions/prepare-node-test-matrix-action/test/index.js
+++ b/.github/actions/prepare-node-test-matrix-action/test/index.js
@@ -61,22 +61,30 @@ exports.main = function () {
     Assert.deepStrictEqual(exports.getOutput(new Date('2020-07-01'), { engines: { node: '^14' } }), [
         '::set-output name=node-version::[14]',
         '::set-output name=lts-latest::12',
-        '::set-output name=runs-on::["ubuntu-latest"]'
+        '::set-output name=runs-on::["ubuntu-latest"]',
+        '::set-output name=include::[]',
+        '::set-output name=exclude::[]'
     ]);
     Assert.deepStrictEqual(exports.getOutput(new Date('2020-07-01'), { engines: { node: '*' } }), [
         '::set-output name=node-version::[14,12,10,8,6,4]',
         '::set-output name=lts-latest::12',
-        '::set-output name=runs-on::["ubuntu-latest"]'
+        '::set-output name=runs-on::["ubuntu-latest"]',
+        '::set-output name=include::[]',
+        '::set-output name=exclude::[]'
     ]);
     Assert.deepStrictEqual(exports.getOutput(new Date('2020-07-01'), { engines: { node: '^14 || ^12 || ^10' } }), [
         '::set-output name=node-version::[14,12,10]',
         '::set-output name=lts-latest::12',
-        '::set-output name=runs-on::["ubuntu-latest"]'
+        '::set-output name=runs-on::["ubuntu-latest"]',
+        '::set-output name=include::[]',
+        '::set-output name=exclude::[]'
     ]);
     Assert.deepStrictEqual(exports.getOutput(new Date('2010-07-01'), { engines: { node: '*' } }), [
         '::set-output name=node-version::[]',
         '::set-output name=lts-latest::4',
-        '::set-output name=runs-on::["ubuntu-latest"]'
+        '::set-output name=runs-on::["ubuntu-latest"]',
+        '::set-output name=include::[]',
+        '::set-output name=exclude::[]'
     ]);
 
 
@@ -86,27 +94,37 @@ exports.main = function () {
     Assert.deepStrictEqual(exports.getOutput(new Date('2020-07-01'), { engines: { node: '^10' } }), [
         '::set-output name=node-version::[14,12,10]',
         '::set-output name=lts-latest::12',
-        '::set-output name=runs-on::["ubuntu-latest"]'
+        '::set-output name=runs-on::["ubuntu-latest"]',
+        '::set-output name=include::[]',
+        '::set-output name=exclude::[]'
     ]);
     Assert.deepStrictEqual(exports.getOutput(new Date('2020-11-01'), { engines: { node: '^10' } }), [
         '::set-output name=node-version::[15,14,12,10]',
         '::set-output name=lts-latest::14',
-        '::set-output name=runs-on::["ubuntu-latest"]'
+        '::set-output name=runs-on::["ubuntu-latest"]',
+        '::set-output name=include::[]',
+        '::set-output name=exclude::[]'
     ]);
     Assert.deepStrictEqual(exports.getOutput(new Date('2021-05-01'), { engines: { node: '^10' } }), [
         '::set-output name=node-version::[16,15,14,12,10]',
         '::set-output name=lts-latest::14',
-        '::set-output name=runs-on::["ubuntu-latest"]'
+        '::set-output name=runs-on::["ubuntu-latest"]',
+        '::set-output name=include::[]',
+        '::set-output name=exclude::[]'
     ]);
     Assert.deepStrictEqual(exports.getOutput(new Date('2021-07-01'), { engines: { node: '^10' } }), [
         '::set-output name=node-version::[16,14,12,10]',
         '::set-output name=lts-latest::14',
-        '::set-output name=runs-on::["ubuntu-latest"]'
+        '::set-output name=runs-on::["ubuntu-latest"]',
+        '::set-output name=include::[]',
+        '::set-output name=exclude::[]'
     ]);
     Assert.deepStrictEqual(exports.getOutput(new Date('2021-11-01'), { engines: { node: '^10' } }), [
         '::set-output name=node-version::[17,16,14,12,10]',
         '::set-output name=lts-latest::16',
-        '::set-output name=runs-on::["ubuntu-latest"]'
+        '::set-output name=runs-on::["ubuntu-latest"]',
+        '::set-output name=include::[]',
+        '::set-output name=exclude::[]'
     ]);
 
 
@@ -114,27 +132,37 @@ exports.main = function () {
     Assert.deepStrictEqual(exports.getOutput(new Date('2020-07-01'), { engines: { node: '^10' } }), [
         '::set-output name=node-version::[12,10]',
         '::set-output name=lts-latest::12',
-        '::set-output name=runs-on::["ubuntu-latest"]'
+        '::set-output name=runs-on::["ubuntu-latest"]',
+        '::set-output name=include::[]',
+        '::set-output name=exclude::[]'
     ]);
     Assert.deepStrictEqual(exports.getOutput(new Date('2020-11-01'), { engines: { node: '^10' } }), [
         '::set-output name=node-version::[14,12,10]',
         '::set-output name=lts-latest::14',
-        '::set-output name=runs-on::["ubuntu-latest"]'
+        '::set-output name=runs-on::["ubuntu-latest"]',
+        '::set-output name=include::[]',
+        '::set-output name=exclude::[]'
     ]);
     Assert.deepStrictEqual(exports.getOutput(new Date('2021-05-01'), { engines: { node: '^10' } }), [
         '::set-output name=node-version::[14,12,10]',
         '::set-output name=lts-latest::14',
-        '::set-output name=runs-on::["ubuntu-latest"]'
+        '::set-output name=runs-on::["ubuntu-latest"]',
+        '::set-output name=include::[]',
+        '::set-output name=exclude::[]'
     ]);
     Assert.deepStrictEqual(exports.getOutput(new Date('2021-07-01'), { engines: { node: '^10' } }), [
         '::set-output name=node-version::[14,12,10]',
         '::set-output name=lts-latest::14',
-        '::set-output name=runs-on::["ubuntu-latest"]'
+        '::set-output name=runs-on::["ubuntu-latest"]',
+        '::set-output name=include::[]',
+        '::set-output name=exclude::[]'
     ]);
     Assert.deepStrictEqual(exports.getOutput(new Date('2021-11-01'), { engines: { node: '^10' } }), [
         '::set-output name=node-version::[16,14,12,10]',
         '::set-output name=lts-latest::16',
-        '::set-output name=runs-on::["ubuntu-latest"]'
+        '::set-output name=runs-on::["ubuntu-latest"]',
+        '::set-output name=include::[]',
+        '::set-output name=exclude::[]'
     ]);
 
 
@@ -142,27 +170,37 @@ exports.main = function () {
     Assert.deepStrictEqual(exports.getOutput(new Date('2020-07-01'), { engines: { node: '^10' } }), [
         '::set-output name=node-version::[14,13,12,11,10]',
         '::set-output name=lts-latest::12',
-        '::set-output name=runs-on::["ubuntu-latest"]'
+        '::set-output name=runs-on::["ubuntu-latest"]',
+        '::set-output name=include::[]',
+        '::set-output name=exclude::[]'
     ]);
     Assert.deepStrictEqual(exports.getOutput(new Date('2020-11-01'), { engines: { node: '^10' } }), [
         '::set-output name=node-version::[15,14,13,12,11,10]',
         '::set-output name=lts-latest::14',
-        '::set-output name=runs-on::["ubuntu-latest"]'
+        '::set-output name=runs-on::["ubuntu-latest"]',
+        '::set-output name=include::[]',
+        '::set-output name=exclude::[]'
     ]);
     Assert.deepStrictEqual(exports.getOutput(new Date('2021-05-01'), { engines: { node: '^10' } }), [
         '::set-output name=node-version::[16,15,14,13,12,11,10]',
         '::set-output name=lts-latest::14',
-        '::set-output name=runs-on::["ubuntu-latest"]'
+        '::set-output name=runs-on::["ubuntu-latest"]',
+        '::set-output name=include::[]',
+        '::set-output name=exclude::[]'
     ]);
     Assert.deepStrictEqual(exports.getOutput(new Date('2021-07-01'), { engines: { node: '^10' } }), [
         '::set-output name=node-version::[16,15,14,13,12,11,10]',
         '::set-output name=lts-latest::14',
-        '::set-output name=runs-on::["ubuntu-latest"]'
+        '::set-output name=runs-on::["ubuntu-latest"]',
+        '::set-output name=include::[]',
+        '::set-output name=exclude::[]'
     ]);
     Assert.deepStrictEqual(exports.getOutput(new Date('2021-11-01'), { engines: { node: '^10' } }), [
         '::set-output name=node-version::[17,16,15,14,13,12,11,10]',
         '::set-output name=lts-latest::16',
-        '::set-output name=runs-on::["ubuntu-latest"]'
+        '::set-output name=runs-on::["ubuntu-latest"]',
+        '::set-output name=include::[]',
+        '::set-output name=exclude::[]'
     ]);
 
     // runs-on - simple comma separated list
@@ -170,7 +208,9 @@ exports.main = function () {
     Assert.deepStrictEqual(exports.getOutput(new Date('2020-07-01'), { engines: { node: '^14' } }), [
         '::set-output name=node-version::[14]',
         '::set-output name=lts-latest::12',
-        '::set-output name=runs-on::["ubuntu-latest","windows-latest","macos-latest"]'
+        '::set-output name=runs-on::["ubuntu-latest","windows-latest","macos-latest"]',
+        '::set-output name=include::[]',
+        '::set-output name=exclude::[]'
     ]);
 };
 

--- a/.github/actions/prepare-node-test-matrix-action/test/index.js
+++ b/.github/actions/prepare-node-test-matrix-action/test/index.js
@@ -212,6 +212,16 @@ exports.main = function () {
         '::set-output name=include::[{"runs-on":"ubuntu-latest","node-version":14,"experimental":true},{"runs-on":"windows-latest","node-version":14,"experimental":true},{"runs-on":"macos-latest","node-version":14,"experimental":true}]',
         '::set-output name=exclude::[]'
     ]);
+
+    // runs-on - YAML
+    process.env = { ...originalEnv, 'INPUT_RUNS-ON': '- ubuntu-latest\n- windows-latest\n- macos-latest\n' };
+    Assert.deepStrictEqual(exports.getOutput(new Date('2020-07-01'), { engines: { node: '^14' } }), [
+        '::set-output name=node-version::[]',
+        '::set-output name=lts-latest::12',
+        '::set-output name=runs-on::["ubuntu-latest","windows-latest","macos-latest"]',
+        '::set-output name=include::[{"runs-on":"ubuntu-latest","node-version":14,"experimental":true},{"runs-on":"windows-latest","node-version":14,"experimental":true},{"runs-on":"macos-latest","node-version":14,"experimental":true}]',
+        '::set-output name=exclude::[]'
+    ]);
 };
 
 

--- a/.github/actions/prepare-node-test-matrix-action/test/index.js
+++ b/.github/actions/prepare-node-test-matrix-action/test/index.js
@@ -222,6 +222,16 @@ exports.main = function () {
         '::set-output name=include::[{"runs-on":"ubuntu-latest","node-version":14,"experimental":true},{"runs-on":"windows-latest","node-version":14,"experimental":true},{"runs-on":"macos-latest","node-version":14,"experimental":true}]',
         '::set-output name=exclude::[]'
     ]);
+
+    // includes - sets missing `experimental`, sets missing `runs-on`
+    process.env = { ...originalEnv, 'INPUT_RUNS-ON': '- ubuntu-latest\n- windows-latest\n- macos-latest\n', 'INPUT_INCLUDE': '- node-version: 15\n  runs-on: ubuntu-latest\n- node-version: 13' };
+    Assert.deepStrictEqual(exports.getOutput(new Date('2020-07-01'), { engines: { node: '^14' } }), [
+        '::set-output name=node-version::[]',
+        '::set-output name=lts-latest::12',
+        '::set-output name=runs-on::["ubuntu-latest","windows-latest","macos-latest"]',
+        '::set-output name=include::[{"runs-on":"ubuntu-latest","node-version":14,"experimental":true},{"runs-on":"windows-latest","node-version":14,"experimental":true},{"runs-on":"macos-latest","node-version":14,"experimental":true},{"runs-on":"ubuntu-latest","node-version":15,"experimental":false},{"runs-on":"ubuntu-latest","node-version":13,"experimental":false},{"runs-on":"windows-latest","node-version":13,"experimental":false},{"runs-on":"macos-latest","node-version":13,"experimental":false}]',
+        '::set-output name=exclude::[]'
+    ]);
 };
 
 

--- a/.github/actions/prepare-node-test-matrix-action/test/index.js
+++ b/.github/actions/prepare-node-test-matrix-action/test/index.js
@@ -59,22 +59,22 @@ exports.main = function () {
 
     process.env = { ...originalEnv };
     Assert.deepStrictEqual(exports.getOutput(new Date('2020-07-01'), { engines: { node: '^14' } }), [
-        '::set-output name=matrix::[14]',
+        '::set-output name=node-version::[14]',
         '::set-output name=lts-latest::12',
         '::set-output name=runs-on::["ubuntu-latest"]'
     ]);
     Assert.deepStrictEqual(exports.getOutput(new Date('2020-07-01'), { engines: { node: '*' } }), [
-        '::set-output name=matrix::[14,12,10,8,6,4]',
+        '::set-output name=node-version::[14,12,10,8,6,4]',
         '::set-output name=lts-latest::12',
         '::set-output name=runs-on::["ubuntu-latest"]'
     ]);
     Assert.deepStrictEqual(exports.getOutput(new Date('2020-07-01'), { engines: { node: '^14 || ^12 || ^10' } }), [
-        '::set-output name=matrix::[14,12,10]',
+        '::set-output name=node-version::[14,12,10]',
         '::set-output name=lts-latest::12',
         '::set-output name=runs-on::["ubuntu-latest"]'
     ]);
     Assert.deepStrictEqual(exports.getOutput(new Date('2010-07-01'), { engines: { node: '*' } }), [
-        '::set-output name=matrix::[]',
+        '::set-output name=node-version::[]',
         '::set-output name=lts-latest::4',
         '::set-output name=runs-on::["ubuntu-latest"]'
     ]);
@@ -84,27 +84,27 @@ exports.main = function () {
 
     process.env = { ...originalEnv, 'INPUT_UPGRADE-POLICY': 'lts' };
     Assert.deepStrictEqual(exports.getOutput(new Date('2020-07-01'), { engines: { node: '^10' } }), [
-        '::set-output name=matrix::[14,12,10]',
+        '::set-output name=node-version::[14,12,10]',
         '::set-output name=lts-latest::12',
         '::set-output name=runs-on::["ubuntu-latest"]'
     ]);
     Assert.deepStrictEqual(exports.getOutput(new Date('2020-11-01'), { engines: { node: '^10' } }), [
-        '::set-output name=matrix::[15,14,12,10]',
+        '::set-output name=node-version::[15,14,12,10]',
         '::set-output name=lts-latest::14',
         '::set-output name=runs-on::["ubuntu-latest"]'
     ]);
     Assert.deepStrictEqual(exports.getOutput(new Date('2021-05-01'), { engines: { node: '^10' } }), [
-        '::set-output name=matrix::[16,15,14,12,10]',
+        '::set-output name=node-version::[16,15,14,12,10]',
         '::set-output name=lts-latest::14',
         '::set-output name=runs-on::["ubuntu-latest"]'
     ]);
     Assert.deepStrictEqual(exports.getOutput(new Date('2021-07-01'), { engines: { node: '^10' } }), [
-        '::set-output name=matrix::[16,14,12,10]',
+        '::set-output name=node-version::[16,14,12,10]',
         '::set-output name=lts-latest::14',
         '::set-output name=runs-on::["ubuntu-latest"]'
     ]);
     Assert.deepStrictEqual(exports.getOutput(new Date('2021-11-01'), { engines: { node: '^10' } }), [
-        '::set-output name=matrix::[17,16,14,12,10]',
+        '::set-output name=node-version::[17,16,14,12,10]',
         '::set-output name=lts-latest::16',
         '::set-output name=runs-on::["ubuntu-latest"]'
     ]);
@@ -112,27 +112,27 @@ exports.main = function () {
 
     process.env = { ...originalEnv, 'INPUT_UPGRADE-POLICY': 'lts/strict' };
     Assert.deepStrictEqual(exports.getOutput(new Date('2020-07-01'), { engines: { node: '^10' } }), [
-        '::set-output name=matrix::[12,10]',
+        '::set-output name=node-version::[12,10]',
         '::set-output name=lts-latest::12',
         '::set-output name=runs-on::["ubuntu-latest"]'
     ]);
     Assert.deepStrictEqual(exports.getOutput(new Date('2020-11-01'), { engines: { node: '^10' } }), [
-        '::set-output name=matrix::[14,12,10]',
+        '::set-output name=node-version::[14,12,10]',
         '::set-output name=lts-latest::14',
         '::set-output name=runs-on::["ubuntu-latest"]'
     ]);
     Assert.deepStrictEqual(exports.getOutput(new Date('2021-05-01'), { engines: { node: '^10' } }), [
-        '::set-output name=matrix::[14,12,10]',
+        '::set-output name=node-version::[14,12,10]',
         '::set-output name=lts-latest::14',
         '::set-output name=runs-on::["ubuntu-latest"]'
     ]);
     Assert.deepStrictEqual(exports.getOutput(new Date('2021-07-01'), { engines: { node: '^10' } }), [
-        '::set-output name=matrix::[14,12,10]',
+        '::set-output name=node-version::[14,12,10]',
         '::set-output name=lts-latest::14',
         '::set-output name=runs-on::["ubuntu-latest"]'
     ]);
     Assert.deepStrictEqual(exports.getOutput(new Date('2021-11-01'), { engines: { node: '^10' } }), [
-        '::set-output name=matrix::[16,14,12,10]',
+        '::set-output name=node-version::[16,14,12,10]',
         '::set-output name=lts-latest::16',
         '::set-output name=runs-on::["ubuntu-latest"]'
     ]);
@@ -140,27 +140,27 @@ exports.main = function () {
 
     process.env = { ...originalEnv, 'INPUT_UPGRADE-POLICY': 'all' };
     Assert.deepStrictEqual(exports.getOutput(new Date('2020-07-01'), { engines: { node: '^10' } }), [
-        '::set-output name=matrix::[14,13,12,11,10]',
+        '::set-output name=node-version::[14,13,12,11,10]',
         '::set-output name=lts-latest::12',
         '::set-output name=runs-on::["ubuntu-latest"]'
     ]);
     Assert.deepStrictEqual(exports.getOutput(new Date('2020-11-01'), { engines: { node: '^10' } }), [
-        '::set-output name=matrix::[15,14,13,12,11,10]',
+        '::set-output name=node-version::[15,14,13,12,11,10]',
         '::set-output name=lts-latest::14',
         '::set-output name=runs-on::["ubuntu-latest"]'
     ]);
     Assert.deepStrictEqual(exports.getOutput(new Date('2021-05-01'), { engines: { node: '^10' } }), [
-        '::set-output name=matrix::[16,15,14,13,12,11,10]',
+        '::set-output name=node-version::[16,15,14,13,12,11,10]',
         '::set-output name=lts-latest::14',
         '::set-output name=runs-on::["ubuntu-latest"]'
     ]);
     Assert.deepStrictEqual(exports.getOutput(new Date('2021-07-01'), { engines: { node: '^10' } }), [
-        '::set-output name=matrix::[16,15,14,13,12,11,10]',
+        '::set-output name=node-version::[16,15,14,13,12,11,10]',
         '::set-output name=lts-latest::14',
         '::set-output name=runs-on::["ubuntu-latest"]'
     ]);
     Assert.deepStrictEqual(exports.getOutput(new Date('2021-11-01'), { engines: { node: '^10' } }), [
-        '::set-output name=matrix::[17,16,15,14,13,12,11,10]',
+        '::set-output name=node-version::[17,16,15,14,13,12,11,10]',
         '::set-output name=lts-latest::16',
         '::set-output name=runs-on::["ubuntu-latest"]'
     ]);
@@ -168,7 +168,7 @@ exports.main = function () {
     // runs-on - simple comma separated list
     process.env = { ...originalEnv, 'INPUT_RUNS-ON': 'ubuntu-latest, windows-latest, macos-latest' };
     Assert.deepStrictEqual(exports.getOutput(new Date('2020-07-01'), { engines: { node: '^14' } }), [
-        '::set-output name=matrix::[14]',
+        '::set-output name=node-version::[14]',
         '::set-output name=lts-latest::12',
         '::set-output name=runs-on::["ubuntu-latest","windows-latest","macos-latest"]'
     ]);

--- a/.github/workflows/node-test.yaml
+++ b/.github/workflows/node-test.yaml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      node-version: ${{ steps.set-matrix.outputs.node-version }}
       runs-on: ${{ steps.set-matrix.outputs.runs-on }}
       lts-latest: ${{ steps.set-matrix.outputs.lts-latest }}
 
@@ -61,7 +61,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ${{ fromJson(needs.prepare-node-matrix.outputs.matrix) }}
+        node-version: ${{ fromJson(needs.prepare-node-matrix.outputs.node-version) }}
         runs-on: ${{ fromJson(needs.prepare-node-matrix.outputs.runs-on) }}
 
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/node-test.yaml
+++ b/.github/workflows/node-test.yaml
@@ -82,8 +82,10 @@ jobs:
         runs-on: ${{ fromJson(needs.prepare-node-matrix.outputs.runs-on) }}
         include: ${{ fromJson(needs.prepare-node-matrix.outputs.include) }}
         exclude: ${{ fromJson(needs.prepare-node-matrix.outputs.exclude) }}
+        experimental: [false]
 
     runs-on: ${{ matrix.runs-on }}
+    continue-on-error: ${{ matrix.experimental }}
 
     steps:
 

--- a/.github/workflows/node-test.yaml
+++ b/.github/workflows/node-test.yaml
@@ -7,9 +7,22 @@ on:
         default: lts
         required: false
         type: string
+
       runs-on:
-        description: "Comma separated list of runner labels (note: not YAML!), see https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idruns-on."
+        description: "Comma separated list (or a string with an array in YAML) of runner labels, see https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idruns-on."
         default: "ubuntu-latest"
+        required: false
+        type: string
+
+      include:
+        description: "A string with additional matrix combinations as a YAML array of objects with the following keys: node-version, runs-on, experimental"
+        default: "[]"
+        required: false
+        type: string
+
+      exclude:
+        description: "A string with matrix combinations to be skipped as a YAML array of objects with the following keys: node-version, runs-on"
+        default: "[]"
         required: false
         type: string
 
@@ -43,6 +56,8 @@ jobs:
       node-version: ${{ steps.set-matrix.outputs.node-version }}
       runs-on: ${{ steps.set-matrix.outputs.runs-on }}
       lts-latest: ${{ steps.set-matrix.outputs.lts-latest }}
+      include: ${{ steps.set-matrix.outputs.include }}
+      exclude: ${{ steps.set-matrix.outputs.exclude }}
 
     steps:
 
@@ -55,6 +70,8 @@ jobs:
       with:
         upgrade-policy: ${{ inputs.upgrade-policy }}
         runs-on: ${{ inputs.runs-on }}
+        include: ${{ inputs.include }}
+        exclude: ${{ inputs.exclude }}
 
   test:
     needs: prepare-node-matrix
@@ -63,6 +80,8 @@ jobs:
       matrix:
         node-version: ${{ fromJson(needs.prepare-node-matrix.outputs.node-version) }}
         runs-on: ${{ fromJson(needs.prepare-node-matrix.outputs.runs-on) }}
+        include: ${{ fromJson(needs.prepare-node-matrix.outputs.include) }}
+        exclude: ${{ fromJson(needs.prepare-node-matrix.outputs.exclude) }}
 
     runs-on: ${{ matrix.runs-on }}
 


### PR DESCRIPTION
- [x] Builds on top of #28 
- Closes #3 
- Adds support for custom `include` / `exclude` matrix combos
    - Unlike Github, this will automatically fill in the default values
- Adds support for `experimental` flag in the matrix - an experimental combo that fails will not fail the whole workflow
    - This also allows us to mark non-LTS/pre-LTS versions as `experimental` by default when `upgradePolicy: lts`
- Accepts YAML in `runs-on` (I originally didn't add that to avoid dragging in `yaml` as a dep, but since it's now there - no reason not to do it)
- I promise I'll write up proper documentation (#27)
- Example run:
    - Config: https://github.com/dominykas/pkgjs-action/blob/baca2f6cd96961e4c21a57e0e79c81670b2946bf/.github/workflows/ci.yaml#L12-L20
    - Result: https://github.com/dominykas/pkgjs-action/actions/runs/1454750367
