### PR TITLE
Support setting arbitrary secrets for tests step

### DIFF
--- a/.github/workflows/node-test.yaml
+++ b/.github/workflows/node-test.yaml
@@ -46,6 +46,11 @@ on:
         required: false
         type: string
 
+    secrets:
+      test-secrets:
+        description: "A JSON object with the secret environment variables to be set for the 'Run tests' step. Values will be masked in output."
+        required: false
+
 jobs:
 
   prepare-node-matrix:
@@ -127,11 +132,31 @@ jobs:
       uses: ./.github/tmp/post-install-steps
 
 
+    - name: Set environment variables for tests
+      id: set-env-vars-for-tests
+      shell: bash
+      run: |
+        # mask all values in the input vars
+        echo ${INPUT_VARS} | jq -c -r '.[] | "::add-mask::" + .'
+
+        # set the matrix variables into env for tests
+        MERGED_VARS=$(cat <<EOF | jq -c -s '.[0] * .[1]'
+          ${INPUT_VARS}
+          {
+            "MATRIX_NODE_VERSION":"${{ matrix.node-version }}",
+            "NODE_LTS_LATEST":"${{ needs.prepare-node-matrix.outputs.lts-latest }}"
+          }
+        EOF
+        )
+
+        # output the merged variables
+        echo "::set-output name=env-vars::${MERGED_VARS}"
+      env:
+        INPUT_VARS: ${{ secrets.test-secrets || '{}' }}
+
     - name: Run tests
       run: ${{ inputs.test-command }}
-      env:
-        MATRIX_NODE_VERSION: ${{ matrix.node-version }}
-        NODE_LTS_LATEST: ${{ needs.prepare-node-matrix.outputs.lts-latest }}
+      env: ${{ fromJson(steps.set-env-vars-for-tests.outputs.env-vars) }}
 
     - name: Run post-test steps
       if: ${{ inputs.post-test-steps }}


### PR DESCRIPTION
Closes #32 

Sometimes tests require secret tokens to run (e.g. https://github.com/pkgjs/wiby needs `GITHUB_TOKEN` to properly test integration with Github). Reusable workflows do not make this easy - unlike regular steps, you're not allowed to set `jobs.<job_id>.env` for reusable workflows; the env vars set on the calling workflow are not passed through; the secrets need to be explicitly enumerated in the called (shared) workflow.

Hence the hack - pass the secrets as a JSON object 🤷‍♂️.

Usage:

```
jobs:
  test:
    uses: pkgjs/action/.github/workflows/node-test.yaml@main
    secrets:
      test-secrets: |-
        {
          "VERY_SECRET": ${{ toJSON(secrets.VERY_SECRET) }} 
        }
```

The param is called `test-secrets`, because it only sets the values for the test step. We have scope to explicitly add `install-secrets`, `checkout-secrets`, etc in the future.

I'll be [writing up the documentation next](https://github.com/pkgjs/action/issues/27), and I'll make sure to add the usual caveats of leaking secrets via environment.

Test runs:

- Setting a `TESTING_TESTING` secret, but it is not available in the repo secrets: https://github.com/dominykas/pkgjs-action/actions/runs/1646277491/attempts/1 (there's a warning in the logs)
- `TESTING_TESTING` is set up correctly: https://github.com/dominykas/pkgjs-action/actions/runs/1646277491/attempts/2
- No `secrets` configured for the workflow: https://github.com/dominykas/pkgjs-action/actions/runs/1646292401

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
