### PR TITLE
Run `npm ci` when a lockfile is available

### DIFF
--- a/.github/workflows/node-test.yaml
+++ b/.github/workflows/node-test.yaml
@@ -116,8 +116,19 @@ jobs:
       uses: ./.github/tmp/post-checkout-steps
 
 
+    - name: Prepare install script
+      id: prepare-install-script
+      shell: bash
+      run: |
+        if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]
+        then
+          echo "::set-output name=install-command::npm ci"
+        else
+          echo "::set-output name=install-command::npm install"
+        fi
+
     - name: Install dependencies
-      run: npm install
+      run: ${{ steps.prepare-install-script.outputs.install-command }}
       env:
         MATRIX_NODE_VERSION: ${{ matrix.node-version }}
         NODE_LTS_LATEST: ${{ needs.prepare-node-matrix.outputs.lts-latest }}

--- a/.github/workflows/node-test.yaml
+++ b/.github/workflows/node-test.yaml
@@ -120,7 +120,7 @@ jobs:
       id: prepare-install-script
       shell: bash
       run: |
-        if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]
+        if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ] || [ -f yarn.lock ]
         then
           echo "::set-output name=install-command::npm ci"
         else


### PR DESCRIPTION
Closes #8.

Doing this as a separate step, because I'd like to keep the default shell (Powershell on Windows) for the actual install step (I suspect we'll have to make it configurable, but that's out of scope here - will wait for someone to ask for that).

Test runs:

- shrinkwrap: https://github.com/dominykas/pkgjs-action/actions/runs/1647166714
- package-lock: https://github.com/dominykas/pkgjs-action/actions/runs/1647168303
- no lockfile: https://github.com/dominykas/pkgjs-action/actions/runs/1647171945
