### PR TITLE
Fix `deleteRef()` params

### DIFF
--- a/.github/workflows/update-release-tag.yaml
+++ b/.github/workflows/update-release-tag.yaml
@@ -51,14 +51,14 @@ jobs:
 
           try {
             await github.rest.git.deleteRef({
-              ref: `refs/tags/${{ steps.new-tag.outputs.major }}`,
+              ref: `tags/${{ steps.new-tag.outputs.major }}`,
               owner: context.repo.owner,
               repo: context.repo.repo
             });
             console.log(`Deleted tags/${{ steps.new-tag.outputs.major }}.`);
           }
           catch (e) {
-            console.log(`Failed to delete tags/${{ steps.new-tag.outputs.major }} - assuming it never existed.`, e);
+            console.log(`IGNORED ERROR: failed to delete tags/${{ steps.new-tag.outputs.major }} - assuming it never existed: ${e}`);
           }
 
           await github.rest.git.createRef({
@@ -69,15 +69,21 @@ jobs:
           });
           console.log(`Created tags/${{ steps.new-tag.outputs.major }} at ${context.sha}.`);
 
+    - name: Move minor tag ${{ steps.new-tag.outputs.minor }}
+      if: ${{ steps.new-tag.outputs.minor }}
+      uses: actions/github-script@v6
+      with:
+        script: |
+
           try {
             await github.rest.git.deleteRef({
-              ref: `refs/tags/${{ steps.new-tag.outputs.minor }}`,
+              ref: `tags/${{ steps.new-tag.outputs.minor }}`,
               owner: context.repo.owner,
               repo: context.repo.repo
             });
           }
           catch (e) {
-            console.log(`Failed to delete tags/${{ steps.new-tag.outputs.minor }} - assuming it never existed.`, e);
+            console.log(`IGNORED ERROR: failed to delete tags/${{ steps.new-tag.outputs.minor }} - assuming it never existed: ${e}`);
           }
 
           await github.rest.git.createRef({


### PR DESCRIPTION
Counterintuitively, `deleteRef()` takes a `ref` without the `refs/` prefix, whereas `createRef()` requires the `refs/` prefix to be there.

- This also splits minor/major version update into steps
- This also somewhat improves the logged messages (at least for the people who are doing the releasing, i.e. me)

Test run in my fork: https://github.com/dominykas/pkgjs-action/runs/5770797517?check_suite_focus=true (showcases both - existing tag and no pre-existing tag cases)