### PR TITLE
Provide a default for `fromJson()`

### DIFF
--- a/.github/workflows/node-test.yaml
+++ b/.github/workflows/node-test.yaml
@@ -199,7 +199,7 @@ jobs:
 
     - name: Run tests
       run: ${{ inputs.test-command }}
-      env: ${{ fromJson(steps.set-env-vars-for-tests.outputs.env-vars) }}
+      env: ${{ fromJson(steps.set-env-vars-for-tests.outputs.env-vars || '{}') }}
 
     - name: Run post-test steps
       if: ${{ inputs.post-test-steps }}


### PR DESCRIPTION
`fromJson()` gets evaluated even if the "Run tests" step will be skipped due to earlier failues. As the "Set environment variables for tests" step could also have been skipped, the `env-vars` output will be missing and will fail to parse.


## Before

Original bug seen in https://github.com/nearform/fast-jwt/runs/5725336317?check_suite_focus=true:

![Screen Shot 2022-03-31 at 15 35 33](https://user-images.githubusercontent.com/505619/161056010-f227aebe-b08f-42bb-bd31-db99da81b12f.png)

Notice how the "Install dependencies" step failed, but by default, GH expands "Run tests" step with an obscure error.

## After

https://github.com/dominykas/pkgjs-action/runs/5770972093?check_suite_focus=true

![Screen Shot 2022-03-31 at 15 36 33](https://user-images.githubusercontent.com/505619/161056183-67f10d8c-08b6-49d5-a09b-599400a1293a.png)

Notice how the "Run tests" step is now correctly skipped.