### PR TITLE
refactor: replace set-output with `GITHUB_OUTPUT` environment files writes

### DIFF
--- a/.github/workflows/node-test.yaml
+++ b/.github/workflows/node-test.yaml
@@ -164,9 +164,9 @@ jobs:
       run: |
         if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ] || [ -f yarn.lock ]
         then
-          echo "::set-output name=install-command::npm ci"
+          echo "install-command=npm ci" >> $GITHUB_OUTPUT
         else
-          echo "::set-output name=install-command::npm install"
+          echo "install-command=npm install" >> $GITHUB_OUTPUT
         fi
 
     - name: Install dependencies
@@ -201,7 +201,7 @@ jobs:
         )
 
         # output the merged variables
-        echo "::set-output name=env-vars::${MERGED_VARS}"
+        echo "env-vars=${MERGED_VARS}" >> $GITHUB_OUTPUT
       env:
         INPUT_VARS: ${{ secrets.test-secrets || '{}' }}
 


### PR DESCRIPTION
This PR replaces set-output calls with `GITHUB_OUTPUT` environment files writes as described here:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

I run the CI tests on a local PR and they seem to be green. I expected to have to review this [test file](https://github.com/toomuchdesign/action/blob/replace-set-output/.github/actions/prepare-node-test-matrix-action/test/index.js#L11-L12), but i can't see how it gets actually executed :)

Closes #56

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
