### PR TITLE
fix: pin the action versions

### DIFF
--- a/.github/workflows/node-test.yaml
+++ b/.github/workflows/node-test.yaml
@@ -85,10 +85,10 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
     - name: Prepare the matrix
-      uses: pkgjs/action/.github/actions/prepare-node-test-matrix-action@v0.1.10
+      uses: ${{ github.action_repository }}/.github/actions/prepare-node-test-matrix-action@${{ github.action_ref }}
       id: set-matrix
       with:
         upgrade-policy: ${{ inputs.upgrade-policy }}
@@ -117,31 +117,31 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
     - name: Prepare post-checkout steps
       if: ${{ inputs.post-checkout-steps }}
-      uses: pkgjs/action/.github/actions/prepare-dynamic-steps@v0.1.10
+      uses: ${{ github.action_repository }}/.github/actions/prepare-dynamic-steps@${{ github.action_ref }}
       with:
         steps: ${{ inputs.post-checkout-steps }}
         path: post-checkout-steps
 
     - name: Prepare post-install steps
       if: ${{ inputs.post-install-steps }}
-      uses: pkgjs/action/.github/actions/prepare-dynamic-steps@v0.1.10
+      uses: ${{ github.action_repository }}/.github/actions/prepare-dynamic-steps@${{ github.action_ref }}
       with:
         steps: ${{ inputs.post-install-steps }}
         path: post-install-steps
 
     - name: Prepare post-test steps
       if: ${{ inputs.post-test-steps }}
-      uses: pkgjs/action/.github/actions/prepare-dynamic-steps@v0.1.10
+      uses: ${{ github.action_repository }}/.github/actions/prepare-dynamic-steps@${{ github.action_ref }}
       with:
         steps: ${{ inputs.post-test-steps }}
         path: post-test-steps
 
     - name: Setup Node.js@${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
       with:
         node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/update-release-tag.yaml
+++ b/.github/workflows/update-release-tag.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - name: Get repo HEAD ref
       id: new-tag
-      uses: actions/github-script@v7
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
       with:
         script: |
           
@@ -45,7 +45,7 @@ jobs:
 
     - name: Move major tag ${{ steps.new-tag.outputs.major }}
       if: ${{ steps.new-tag.outputs.major }}
-      uses: actions/github-script@v7
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
       with:
         script: |
 
@@ -71,7 +71,7 @@ jobs:
 
     - name: Move minor tag ${{ steps.new-tag.outputs.minor }}
       if: ${{ steps.new-tag.outputs.minor }}
-      uses: actions/github-script@v7
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
       with:
         script: |
 


### PR DESCRIPTION
See https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
